### PR TITLE
Small bug fixes concerning modifiers

### DIFF
--- a/src/lib/pbox/common/__init__.py
+++ b/src/lib/pbox/common/__init__.py
@@ -1,6 +1,8 @@
 # -*- coding: UTF-8 -*-
 from .config import *
 from .config import __all__ as _config
+from .modifiers import *
+from .modifiers import __all__ as _modifiers
 
-__all__ = _config
+__all__ = _config + _modifiers
 

--- a/src/lib/pbox/common/dataset.py
+++ b/src/lib/pbox/common/dataset.py
@@ -8,6 +8,7 @@ from tinyscript.report import *
 from tqdm import tqdm
 
 from .config import *
+from .modifiers import *
 from .executable import *
 from .utils import *
 from ..items import *
@@ -291,12 +292,12 @@ class Dataset:
         # then apply alterations until the desired percentage is reached
         n, c = int(round(len(self)*p, 0)), 0
         for h in hashes:
-            if any(h in self._alterations.values()):
+            if any(h in altered_hs for altered_hs in self._alterations.values()):
                 continue
             exe = Executable(dataset=self, hash=h)
-            for a in Modifiers(exe):
-                self._alterations.setdefault(a, [])
-                self._alterations[a].append(h)
+            for m in Modifiers(exe):
+                self._alterations.setdefault(m, [])
+                self._alterations[m].append(h)
             c += 1
             if c >= n:
                 break

--- a/src/lib/pbox/common/modifiers/__init__.py
+++ b/src/lib/pbox/common/modifiers/__init__.py
@@ -62,7 +62,7 @@ class Modifiers(list):
                 d = {}
                 d.update(__common__)
                 md = __elf__ if exe.format in expand_formats("ELF") else \
-                     __macho__ if exe.format in expand_formats("Mach-O") \
+                     __macho__ if exe.format in expand_formats("Mach-O") else\
                      __pe__ if exe.format in expand_formats("PE") else []
                 d.update({k: globals()[k] for k in md})
                 kw = {'executable': exe, 'parsed': parsed}


### PR DESCRIPTION
This pull request contains small bug fixes for the *modifiers* of docker-packing-box:
- Modifiers were not imported up to the main dataset tool (fixed in 57716148c2b0d73023f082675b9e61d5ebb380c0)
- Syntax bug in  src/lib/pbox/common/modifiers/\_\_init\_\_.py (fixed in a3b6f0537daace51c77480f17d5bae3bfc34ab16)
- Other small bugs in src/lib/pbox/common/dataset.py (fixed in 483308102223c9ad89a1873f29ff02e77630501c)