### PR TITLE
Implement KMeans visualization

### DIFF
--- a/src/lib/pbox/learning/features/__init__.py
+++ b/src/lib/pbox/learning/features/__init__.py
@@ -3,6 +3,7 @@ import yaml
 from collections import deque
 from functools import cached_property
 from tinyscript import logging, re
+from tinyscript.helpers import  Path
 
 from .extractors import Extractors
 from ...common.config import config
@@ -38,7 +39,7 @@ class MetaFeatures(type):
     @property
     def source(self):
         if not hasattr(self, "_source"):
-            self.source = None  # use the default source from 'config'
+            self._source = None  # use the default source from 'config'
         return self._source
 
     @source.setter

--- a/src/lib/pbox/learning/features/__init__.py
+++ b/src/lib/pbox/learning/features/__init__.py
@@ -39,7 +39,7 @@ class MetaFeatures(type):
     @property
     def source(self):
         if not hasattr(self, "_source"):
-            self._source = None  # use the default source from 'config'
+            self.source = None  # use the default source from 'config'
         return self._source
 
     @source.setter


### PR DESCRIPTION
Implemented KMeans visualization which produces a scatter plot (see [6b82502b2a78723970a6197d5389f27c4259f214](https://github.com/packing-box/experiments-unsupervised-learning/commit/6b82502b2a78723970a6197d5389f27c4259f214)). 
It isn't optimal since it will recompute features for all the data, which has already been done during the `train` phase, but I couldn't manage to do it otherwise.

This pull request also contains small fixes following packing-box/docker-packing-box#28. Some fixes still need to be done on that issue. 
The image that I had produced was using my temporary fix and didn't take last commit into account. 