### PR TITLE
Generalize clustering visualization

### DIFF
--- a/src/lib/pbox/learning/model.py
+++ b/src/lib/pbox/learning/model.py
@@ -605,7 +605,7 @@ class Model:
         if viz is None:
             self.logger.warning("Visualization not available for this algorithm%s" % [" in text mode", ""][export])
             return
-        params = {'feature_names': sorted(self._features.keys()), 'logger': self.logger}
+        params = {'algo_name' : a['name'] ,'feature_names': sorted(self._features.keys()), 'logger': self.logger}
         params.update(kw.pop('viz_params', {}))
         # if visualization requires the original data (e.g. kNN), use self._prepare to create self._data/self._target
         if VISUALIZATIONS.get(a['name']).get("data", False):

--- a/src/lib/pbox/learning/visualization.py
+++ b/src/lib/pbox/learning/visualization.py
@@ -13,7 +13,7 @@ from sklearn.inspection import DecisionBoundaryDisplay
 from sklearn.manifold import TSNE
 from sklearn.neighbors import KNeighborsClassifier
 from sklearn.tree import export_text, plot_tree
-
+from .algorithm import Algorithm 
 
 __all__ = ["VISUALIZATIONS"]
 
@@ -43,6 +43,15 @@ def _preprocess(f):
         return f(*args, **kwargs)
     return _wrapper
 
+def _set_class(f):
+    """ This decorator sets the model class from the algorithm name """
+    @wraps(f)
+    def _wrapper(*args, **kwargs):
+        name = kwargs['algo_name'] 
+        cls = [a.base for a in Algorithm.registry if a.cname == name][0]
+        kwargs['algo_class'] = cls
+        return f(*args, **kwargs)
+    return _wrapper
 
 def image_dt(classifier, width=5, fontsize=10, logger=None, **params):
     params['filled'] = True
@@ -83,11 +92,13 @@ def image_rf(classifier, width=5, fontsize=10, logger=None, **params):
 
 
 @_preprocess
-def image_kmeans(classifier, viz_params={}, logger=None, **params):
+@_set_class
+def image_clustering(classifier, viz_params={}, logger=None, **params):
     X = params['data']
     # retrain KMeans with the preprocessed data (with dimensionality reduced to N=2, hence not using 'classifier')
-    kmeans = KMeans(**params['algo_params'])
-    label = kmeans.fit_predict(X)
+    cls = params['algo_class']
+    cls = cls(**params['algo_params'])
+    label = cls.fit_predict(X)
     # now set color map then plot
     labels = np.unique(label)
     colors = mpl.cm.get_cmap("jet", len(labels))
@@ -109,10 +120,24 @@ def text_rf(classifier, logger=None, **params):
     return s
 
 
+
+# def image_clustering(name):
+#     @wraps(name)
+#     def wrapper(classifier, viz_params={}, logger=None, **params):
+#             [a.base for a in Algorithm.registry if a.name == name][0]
+#             return wrapper(classifier, viz_params={}, logger=None, **params)
+
 VISUALIZATIONS = {
     'DT':     {'image': image_dt, 'text': text_dt},
     'kNN':    {'image': image_knn, 'data': True},
     'RF':     {'image': image_rf, 'text': text_rf},
-    'KMeans': {'image': image_kmeans, 'data': True, 'target': False}
+    'AC': {'image': image_clustering, 'data': True, 'target': False},
+    'AP': {'image': image_clustering, 'data': True, 'target': False},
+    'Birch': {'image': image_clustering, 'data': True, 'target': False},
+    'DBSCAN': {'image': image_clustering, 'data': True, 'target': False},
+    'KMeans': {'image': image_clustering, 'data': True, 'target': False},
+    'MBKMeans': {'image': image_clustering, 'data': True, 'target': False},
+    'MS': {'image': image_clustering, 'data': True, 'target': False},
+    'OPTICS': {'image': image_clustering, 'data': True, 'target': False},
+    'SC': {'image': image_clustering, 'data': True, 'target': False}
 }
-

--- a/src/lib/pbox/learning/visualization.py
+++ b/src/lib/pbox/learning/visualization.py
@@ -119,14 +119,6 @@ def text_rf(classifier, logger=None, **params):
         s += export_text(classifier.estimators_[i], **params)
     return s
 
-
-
-# def image_clustering(name):
-#     @wraps(name)
-#     def wrapper(classifier, viz_params={}, logger=None, **params):
-#             [a.base for a in Algorithm.registry if a.name == name][0]
-#             return wrapper(classifier, viz_params={}, logger=None, **params)
-
 VISUALIZATIONS = {
     'DT':     {'image': image_dt, 'text': text_dt},
     'kNN':    {'image': image_knn, 'data': True},


### PR DESCRIPTION
As discussed, I've generalized the plotting method for all the clustering algorithms. 
It may not be exactly done as discussed yesterday, but it is pretty close and works as expected. 
I had to pass the `algo_name` parameter through the method call form the `model` because I couldn't get it otherwise. 

I'll soon add a method to plot dendograms for the hierarchical clustering algorithms (which can use a scatter plot too). 