### PR TITLE
Add action for ignore-labels and pass parameters

### DIFF
--- a/src/files/tools/model
+++ b/src/files/tools/model
@@ -60,7 +60,7 @@ if __name__ == '__main__':
     test.add_argument("-f", "--features-set", type=ts.file_exists, default=config['features'],
                       help="features set's YAML definition")
     test.add_argument("-u", "--unlabeled", action="store_true", help="do not use assigned labels (if any)")
-    test.add_argument("--ignore-labels", help="while computing metrics, only consider those not requiring labels")
+    test.add_argument("--ignore-labels", action="store_true", help="while computing metrics, only consider those not requiring labels")
     test.add_argument("--sep", default=",", choices=",;|\t", help="set the CSV separator",
                       note="required when using input CSV data instead of a Dataset")
     train = sparsers.add_parser("train", help="train a model on the given dataset")
@@ -78,7 +78,7 @@ if __name__ == '__main__':
     train.add_argument("-r", "--reset", action="store_true", help="reset the model before (re)training")
     train.add_argument("--cv", default=5, type=ts.pos_int, help="number of Cross-Validation folds")
     train.add_argument("--feature", action="extend", nargs="*", help="list of features to be selected")
-    train.add_argument("--ignore-labels", help="while computing metrics, only consider those not requiring labels")
+    train.add_argument("--ignore-labels", action="store_true", help="while computing metrics, only consider those not requiring labels")
     train.add_argument("--n-jobs", default=N_JOBS, help="number of jobs to be run in parallel")
     train.add_argument("--param", action="extend", nargs="*", type=lambda x: x.split(","),
                        help="comma-separated list of parameters for the algorithm",

--- a/src/lib/src/pbox/learning/metrics.py
+++ b/src/lib/src/pbox/learning/metrics.py
@@ -164,7 +164,7 @@ def metric_headers(metrics, **kw):
 
 
 @_convert_output
-def classification_metrics(X, y_pred, y_true=None, y_proba=None, labels=None, sample_weight=None, **kw):
+def classification_metrics(X, y_pred, y_true=None, y_proba=None, labels=None, sample_weight=None, ignore_labels=False, **kw):
     """ Compute some classification metrics based on the true and predicted values. """
     if ignore_labels:
         return
@@ -204,7 +204,7 @@ def clustering_metrics(X, y_pred, y_true=None, ignore_labels=False, **kw):
 
 
 @_convert_output
-def regression_metrics(X, y_pred, y_true=None, **kw):
+def regression_metrics(X, y_pred, y_true=None, ignore_labels=False, **kw):
     """ Compute regression metrics (MSE, MAE) based on the true and predicted values. """
     if ignore_labels:
         return


### PR DESCRIPTION
Added `ignore-labels` parameters to classification and regression metrics, otherwise the name wouldn't be defined. The parameter was already present for clustering metrics. 
Added `action="store_true"` to the command parser for this parameter. 

Works well in this state. 
Note that when labels are present, clustering metrics does not output anything for now. 