### PR TITLE
Improve visualization

### DIFF
--- a/src/files/tools/model
+++ b/src/files/tools/model
@@ -98,10 +98,14 @@ if __name__ == '__main__':
                                help="strategy for imputing missing values")
     viz_dependent.add_argument("-a", "--reduction-algorithm", default="PCA", choices=("ICA", "PCA"),
                                help="dimensionality reduction algorithm")
+    viz_dependent.add_argument("-f", "--features", nargs="*",type=lambda x: x.split(","),help="comma separated list of features to be selected", default="")
     viz_dependent.add_argument("-n", "--n-components", metavar="N", default=20, type=int,
                                help="number of components for dimensionality reduction")
     viz_dependent.add_argument("-p", "--perplexity", metavar="P", default=30, type=int,
                                help="t-SNE perplexity for dimensionality reduction")
+    viz_dependent.add_argument("-r", "--reduce-train-data", action="store_true",
+                               help="reduce the training data",
+                               note="the data is only reduced for the visualization by default")
     initialize(noargs_action="help")
     logger.name = "model"
     logging.configLogger(logger, ["INFO", "DEBUG"][args.verbose], fmt=LOG_FORMATS[args.verbose], relative=True)
@@ -126,7 +130,7 @@ if __name__ == '__main__':
             name = Model(**vars(args))
         if args.command == "visualize":
             args.viz_params = {}
-            for a in ["reduction_algorithm", "imputer_strategy", "n_components", "perplexity"]:
+            for a in ["reduction_algorithm", "imputer_strategy", "n_components", "perplexity", "reduce_train_data", "features"]:
                 args.viz_params[a] = getattr(args, a)
                 delattr(args, a)
         if args.command != "purge" or args.name is not None:


### PR DESCRIPTION
Added the following elements : 
- Added Scaler in the preprocessing. This has given me better visualizations and seems logical, otherwise PCA/ICA/... is used on unscaled data.
- Added possibility to train the visualized algorithm on either the reduced data or the original data (which is better).
- Added visualization of the target labels.
- Added possibility to select features to be viewed and will generate subplots with them. 
- Added titles and legends for the mentioned subplots. Legend will be a colorbar for non-boolean features.

A minor issue that I couldn't solve is that the selected features become a list of lists instead of a list of strings during the parsing. E.g : `[['number_standard_sections', 'is_ep_not_in_code_section']]` instead of `['number_standard_sections', 'is_ep_not_in_code_section']`.
See line 101 in model.py and line 106 in visualization.py

