### PR TITLE
Implement visualization of multiclass labels

### DIFF
--- a/src/files/tools/model
+++ b/src/files/tools/model
@@ -114,6 +114,7 @@ if __name__ == '__main__':
                                help="t-SNE perplexity for dimensionality reduction")
     viz_dependent.add_argument("-r", "--reduce-train-data", action="store_true", help="reduce the training data",
                                note="the data is only reduced for the visualization by default")
+    viz_dependent.add_argument("--multiclass", action="store_true", help="plot multiclass true labels of packers")
     viz_dependent.add_argument("--plot-extensions", action="store_true", help="plot the file extensions")
     viz_dependent.add_argument("--plot-formats", action="store_true", help="plot the file formats")
     initialize(noargs_action="help")
@@ -141,7 +142,7 @@ if __name__ == '__main__':
         if args.command == "visualize":
             args.viz_params = {}
             for a in ["reduction_algorithm", "imputer_strategy", "n_components", "perplexity", "reduce_train_data",
-                      "features", "plot_extensions", "plot_formats"]:
+                      "features", "multiclass", "plot_extensions", "plot_formats"]:
                 args.viz_params[a] = getattr(args, a)
                 delattr(args, a)
         if args.command != "purge" or args.name is not None:

--- a/src/lib/src/pbox/learning/model.py
+++ b/src/lib/src/pbox/learning/model.py
@@ -623,6 +623,7 @@ class Model:
             if not self._prepare(**kw):
                 return
             params['data'], params['format'] = self._data, self._dataset._data['format']
+            params['labels'] =self._dataset._data['label']
             params['extension'] = self._dataset._data['realpath'].apply(lambda p: Path(p).extension)
             if viz_dict.get("target", True):
                 params['target'] = self._target

--- a/src/lib/src/pbox/learning/visualization.py
+++ b/src/lib/src/pbox/learning/visualization.py
@@ -104,24 +104,30 @@ def image_clustering(classifier, **params):
     else : 
         label = cls.fit_predict(X) 
     # now set color map
-    model_labels = np.unique(label)
     colors = mpl.cm.get_cmap("jet")
     # Adjust number of plots and size of figure
     features = params['features'][0]
     n_features = len(features)
     n_plots = 2 + int(params['plot_extensions']) + int(params['plot_formats']) + n_features
     fig, axes = plt.subplots(n_plots ,figsize=(10 , 6 + 2 * n_plots))
-    # Plot cluster labels
-    for i in model_labels:
+    # Plot predicted cluster labels
+    predicted_labels = np.unique(label)
+    for i in predicted_labels:
         axes[0].scatter(X_reduced[label == i, 0], X_reduced[label == i, 1] , label=i, cmap=colors)
     axes[0].set_title("Clusters")
     # Plot true labels
-    colors_bool = mpl.cm.get_cmap("jet", 2)
-    y_labels = np.unique(y.label.ravel())
-    label_map = {0: 'Not packed', 1: 'Packed'}
-    for y_label in y_labels:
-        axes[1].scatter(X_reduced[y.label.ravel() == y_label, 0], X_reduced[y.label.ravel() == y_label, 1],
-                        label=label_map[y_label], color=colors_bool(i), alpha=1.0)
+    if params['multiclass']:
+        y_labels = np.unique(params['labels'])
+        colors_labels = mpl.cm.get_cmap("jet", len(y_labels))
+        label_map = {label: 'Not packed' if label == '-' else f'Packed : {label}' for label in y_labels}
+    else : 
+        colors_labels = mpl.cm.get_cmap("jet", 2)
+        y_labels = np.unique(y.label.ravel())
+        label_map = {0: 'Not packed', 1: 'Packed'}
+    for i, y_label in enumerate(y_labels):
+        labels_mask = params['labels'] == y_label if params['multiclass'] else y.label.ravel() == y_label
+        axes[1].scatter(X_reduced[labels_mask, 0], X_reduced[labels_mask, 1],
+                        label=label_map[y_label], color=colors_labels(i), alpha=1.0)
     axes[1].legend(loc='upper left', bbox_to_anchor=(1, 1))  
     axes[1].set_title("Target")
     # Plot file formats


### PR DESCRIPTION
Since true labels with the packer names were available in `self._dataset._data` in model.py, I use them to be able to plot the multiclass labels. 
E.g. If packers UPX and RLPack are present in a dataset, they will be plotted in different colors and legend will be adapted accordingly, instead of being under the same "Packed" label. 