### PR TITLE
Add dendrograms, zone selection and fixes

### DIFF
--- a/src/files/tools/model
+++ b/src/files/tools/model
@@ -108,6 +108,8 @@ if __name__ == '__main__':
                                help="dimensionality reduction algorithm")
     viz_dependent.add_argument("-f", "--features", nargs="*",type=lambda x: x.split(","),
                                help="comma separated list of features to be selected", default="")
+    viz_dependent.add_argument("-l", "--hierarchy_levels", metavar="H", default=4, type=int,
+                               help="number of levels to display when truncating dendrogram")
     viz_dependent.add_argument("-n", "--n-components", metavar="N", default=20, type=int,
                                help="number of components for dimensionality reduction")
     viz_dependent.add_argument("-p", "--perplexity", metavar="P", default=30, type=int,
@@ -117,6 +119,7 @@ if __name__ == '__main__':
     viz_dependent.add_argument("--multiclass", action="store_true", help="plot multiclass true labels of packers")
     viz_dependent.add_argument("--plot-extensions", action="store_true", help="plot the file extensions")
     viz_dependent.add_argument("--plot-formats", action="store_true", help="plot the file formats")
+    viz_dependent.add_argument('--range', type=float, nargs=4, default=None, help='select range values to plot in format: x_min x_max y_min y_max')
     initialize(noargs_action="help")
     logger.name = "model"
     logging.configLogger(logger, ["INFO", "DEBUG"][args.verbose], fmt=LOG_FORMATS[args.verbose], relative=True)
@@ -142,7 +145,7 @@ if __name__ == '__main__':
         if args.command == "visualize":
             args.viz_params = {}
             for a in ["reduction_algorithm", "imputer_strategy", "n_components", "perplexity", "reduce_train_data",
-                      "features", "multiclass", "plot_extensions", "plot_formats"]:
+                      "features", "multiclass", "plot_extensions", "plot_formats", "range", "hierarchy_levels"]:
                 args.viz_params[a] = getattr(args, a)
                 delattr(args, a)
         if args.command != "purge" or args.name is not None:

--- a/src/lib/src/pbox/learning/dataset.py
+++ b/src/lib/src/pbox/learning/dataset.py
@@ -5,7 +5,6 @@ from tinyscript.report import *
 
 from .executable import Executable
 from .pipeline import *
-from .plot import *
 from ..common.config import *
 from ..common.dataset import Dataset
 from ..common.rendering import progress_bar

--- a/src/lib/src/pbox/learning/visualization.py
+++ b/src/lib/src/pbox/learning/visualization.py
@@ -6,7 +6,8 @@ from contextlib import suppress
 from functools import wraps
 from math import ceil
 from matplotlib.colors import ListedColormap
-from sklearn.cluster import KMeans
+from sklearn.cluster import AgglomerativeClustering
+from scipy.cluster.hierarchy import linkage, fcluster, dendrogram
 from sklearn.decomposition import FastICA, PCA
 from sklearn.impute import SimpleImputer
 from sklearn.inspection import DecisionBoundaryDisplay
@@ -35,7 +36,7 @@ def _preprocess(f):
         X = SimpleImputer(missing_values=np.nan, strategy=kwargs.get('imputer_strategy', "mean")).fit_transform(X)
         X = MinMaxScaler().fit_transform(X)
         # Update the keyword-arguments with the scaled data, since it may be used in the visualization
-        kwargs['data'] = X 
+        kwargs['scaled_data'] = X 
         # preprocess data with a PCA with n components to reduce the high dimensionality (better performance)
         if n < n_cols:
             ra = kwargs.get('reduction_algorithm', "PCA")
@@ -98,25 +99,61 @@ def image_rf(classifier, width=5, fontsize=10, **params):
 @_preprocess
 def image_clustering(classifier, **params):
     X, y = params['data'], params['target']
-    X_reduced = params['reduced_data']        
+    X_reduced = params['reduced_data']  
+    X_scaled = params['scaled_data']      
     # retrain either with the preprocessing data or with the original data
     cls = Algorithm.get(params['algo_name']).base(**params['algo_params'])
     if params.get('reduce_train_data', False):
         label = cls.fit_predict(X_reduced)
     else : 
-        label = cls.fit_predict(X) 
+        label = cls.fit_predict(X_scaled)
+    # Get labels for hierarchical clustering
+    is_hierarchical = isinstance(cls, AgglomerativeClustering)
+    if is_hierarchical: 
+        if params.get('reduce_train_data', False):
+            Z = linkage(X_reduced, method='ward')
+        else : 
+            Z = linkage(X_scaled, method='ward')
+        label = fcluster(Z, t=cls.n_clusters_, criterion='maxclust')
     # now set color map
     colors = mpl.cm.get_cmap("jet")
     # Adjust number of plots and size of figure
     features = params['features'][0]
     n_features = len(features)
-    n_plots = 2 + int(params['plot_extensions']) + int(params['plot_formats']) + n_features
+    n_plots = 2 + int(is_hierarchical) + int(params['plot_extensions']) + int(params['plot_formats']) + n_features
     fig, axes = plt.subplots(n_plots ,figsize=(10 , 6 + 2 * n_plots))
+    current_ax = 0 
+    # Select zone of data to plot
+    if params['range'] is not None:
+        if is_hierarchical:
+            raise ValueError("Error: Zone selection is not compatible with hierarchical clustering")
+        x_min, x_max, y_min, y_max = params['range']
+        range_mask = (X_reduced[:, 0] >= x_min) & (X_reduced[:, 0] <= x_max) & (X_reduced[:, 1] >= y_min) & (X_reduced[:, 1] <= y_max)
+        X_reduced = X_reduced[range_mask]
+        X = X[range_mask]
+        label = label[range_mask]
+        params['labels'] = params['labels'][range_mask]
+        params['extension'] = params['extension'][range_mask]
+        params['format'] =  params['format'][range_mask]
+        if X_reduced.size == 0 :
+            raise ValueError("Error: The selected zone is empty")
+    # Plot dendrogram for hierarchical clustering
+    if is_hierarchical: 
+        d = dendrogram(Z, ax=axes[0], no_plot= True)
+        dendrogram(Z, ax=axes[0], truncate_mode='level', p=params['hierarchy_levels'], leaf_rotation=90., leaf_font_size=8., show_contracted=params['hierarchy_levels'] <= 5)        
+        axes[current_ax].set_title("Dendrogram")
+        current_ax += 1
     # Plot predicted cluster labels
-    predicted_labels = np.unique(label)
-    for i in predicted_labels:
-        axes[0].scatter(X_reduced[label == i, 0], X_reduced[label == i, 1] , label=i, cmap=colors)
-    axes[0].set_title("Clusters")
+    if is_hierarchical:
+        axes[current_ax].scatter(X_reduced[d['leaves'],0],X_reduced[d['leaves'],1], color=d['leaves_color_list'])
+    else : 
+        predicted_labels = np.unique(label)
+        print(predicted_labels)
+        cluster_colors = {i: colors(i / len(predicted_labels)) for i in predicted_labels} if not is_hierarchical else cluster_colors
+        for i in predicted_labels:
+            axes[current_ax].scatter(X_reduced[label == i, 0], X_reduced[label == i, 1] , label=i, color=cluster_colors[i])
+    axes[current_ax].set_title("Clusters")
+    current_ax += 1 
     # Plot true labels
     if params['multiclass']:
         y_labels = np.unique(params['labels'])
@@ -128,50 +165,54 @@ def image_clustering(classifier, **params):
         label_map = {0: 'Not packed', 1: 'Packed'}
     for i, y_label in enumerate(y_labels):
         labels_mask = params['labels'] == y_label if params['multiclass'] else y.label.ravel() == y_label
-        axes[1].scatter(X_reduced[labels_mask, 0], X_reduced[labels_mask, 1],
+        axes[current_ax].scatter(X_reduced[labels_mask, 0], X_reduced[labels_mask, 1],
                         label=label_map[y_label], color=colors_labels(i), alpha=1.0)
-    axes[1].legend(loc='upper left', bbox_to_anchor=(1, 1))  
-    axes[1].set_title("Target")
+    axes[current_ax].legend(loc='upper left', bbox_to_anchor=(1, 1))  
+    axes[current_ax].set_title("Target")
+    current_ax += 1
     # Plot file formats
     if params['plot_formats']:
         unique_formats = np.unique(params['format'])
         for file_format in unique_formats:
             format_mask = params['format'] == file_format
-            axes[2].scatter(X_reduced[format_mask, 0], X_reduced[format_mask, 1],
+            axes[current_ax].scatter(X_reduced[format_mask, 0], X_reduced[format_mask, 1],
                             label=file_format, cmap=colors, alpha=1.0)
-        axes[2].legend(loc='upper left', bbox_to_anchor=(1, 1))
-        axes[2].set_title("File Formats")
+        axes[current_ax].legend(loc='upper left', bbox_to_anchor=(1, 1))
+        axes[current_ax].set_title("File Formats")
+        current_ax += 1 
     # Plot file extensions
     if params['plot_extensions']:
         unique_extensions = np.unique(params['extension'])
         for file_extension in unique_extensions:
             extension_mask = params['extension'] == file_extension
-            axes[2 + int(params['plot_formats'])].scatter(X_reduced[extension_mask, 0], X_reduced[extension_mask, 1],
+            axes[current_ax].scatter(X_reduced[extension_mask, 0], X_reduced[extension_mask, 1],
                             label=file_extension, cmap=colors, alpha=1.0)
-        axes[2 + int(params['plot_formats'])].legend(loc='upper left', bbox_to_anchor=(1, 1))
-        axes[2 + int(params['plot_formats'])].set_title("File Extensions")
+        axes[current_ax].legend(loc='upper left', bbox_to_anchor=(1, 1))
+        axes[current_ax].set_title("File Extensions")
+        current_ax += 1 
     # Plot selected features
     if features :
         for i, feature in enumerate(features) : 
             unique_feature_values = np.unique(X[feature])
             # Plot a continous colorbar if the feature is not boolean and a legend otherwise 
             if len(unique_feature_values) > 2:
-                axes[n_plots - n_features + i].scatter(X_reduced[:, 0], X_reduced[:, 1], c=X[feature].to_numpy(), cmap=colors, alpha=1.0)
+                axes[current_ax].scatter(X_reduced[:, 0], X_reduced[:, 1], c=X[feature].to_numpy(), cmap=colors, alpha=1.0)
                 norm = mpl.colors.Normalize(vmin=X[feature].min(), vmax=X[feature].max())
                 # fig.colorbar(mpl.cm.ScalarMappable(norm=norm, cmap=colors), ax=axes[n_plots - n_features +i],
                 # orientation='vertical')
-                colorbar_ax = fig.add_axes([axes[n_plots - n_features + i].get_position().x1 + 0.02,
-                            axes[n_plots - n_features + i].get_position().y0 - 0.08,
-                            0.02,
-                            axes[n_plots - n_features + i].get_position().height])
+                colorbar_ax = fig.add_axes([axes[current_ax].get_position().x1 + 0.01,
+                            axes[current_ax].get_position().y0 - 0.08,
+                            0.01,
+                            axes[current_ax].get_position().height])
                 fig.colorbar(mpl.cm.ScalarMappable(norm=norm, cmap=colors), cax=colorbar_ax, orientation='vertical')
             else : 
                 label_map = {0: 'False', 1: 'True'}
                 for feature_value in unique_feature_values:
-                    axes[n_plots - n_features + i].scatter(X_reduced[X[feature] == feature_value, 0], X_reduced[X[feature] == feature_value, 1],
+                    axes[current_ax].scatter(X_reduced[X[feature] == feature_value, 0], X_reduced[X[feature] == feature_value, 1],
                                         label=label_map[feature_value], cmap=colors, alpha=1.0)
-                    axes[n_plots - n_features + i].legend(loc='upper left', bbox_to_anchor=(1, 1))  
-            axes[n_plots - n_features + i].set_title(feature)
+                    axes[current_ax].legend(loc='upper left', bbox_to_anchor=(1, 1))  
+            axes[current_ax].set_title(feature)
+            current_ax += 1 
     title = generate_title(params)
     plt.suptitle(title, fontweight="bold", fontsize=14, y=1.01)
     plt.subplots_adjust(hspace=0.5)


### PR DESCRIPTION
This PR adds : 
- Plotting of dendrograms for hierarchical clustering and matching colors between the dendrogram clusters and the scatter plot ones. 
- Ability to select x and y ranges of points to be plotted. 
- A small fix regarding the scaling of the original data. It is now stored in a separate variable, else the features selection wouldn't work correctly since it needs the original unscaled data. 
- A small fix regarding the file deleted in 9504886af0bfd6e3e7945ec138a375a63ed42cb0 that was still being imported and would yield this issue : 
   ```
  ┌──[user@packing-box]──[/mnt/share]──[experiments/exp-upx]──[improve-visualization|+1…2]────────                     ────[172.17.0.4]──[15:21:08]────
  $ dataset plot features upx-PE byte_0_after_ep byte_1_after_ep
  /home/user/.local/lib/python3.10/site-packages/sklearn/base.py:329: UserWarning: Trying to unpickle estimator DecisionTreeClassifier from version pre-0.18 when using version 1.1.3. This might lead to breaking code or invalid results. Use at your own risk. For more info please refer to:
  https://scikit-learn.org/stable/model_persistence.html#security-maintainability-limitations
    warnings.warn(
  Traceback (most recent call last):
    File "/home/user/.opt/tools/dataset", line 3, in <module>
      from pbox import *
    File "/home/user/.local/lib/python3.10/site-packages/pbox/__init__.py", line 4, in <module>
      from .experiment import *
    File "/home/user/.local/lib/python3.10/site-packages/pbox/experiment.py", line 9, in <module>
      from .learning import *
    File "/home/user/.local/lib/python3.10/site-packages/pbox/learning/__init__.py", line 8, in <module>
      from .dataset import *
    File "/home/user/.local/lib/python3.10/site-packages/pbox/learning/dataset.py", line 8, in <module>
      from .plot import *
  ModuleNotFoundError: No module named 'pbox.learning.plot'
   ```
Note that with this file being deleted, it is currently not possible to plot a dataset.