### PR TITLE
Improve set_depth

### DIFF
--- a/src/lib/src/pbox/core/executable/cfg/graph.py
+++ b/src/lib/src/pbox/core/executable/cfg/graph.py
@@ -187,7 +187,11 @@ def set_depth(graph):
         node.soot_block = {'depth': node.size + max_successor_depth, 'idx': None}
         niter -= 1
         return node.soot_block['depth']
-    return (getattr(graph.root_node, "soot_block") or {}).get('depth') or _set_depth(graph.root_node, RECURSION_LIMIT)
+    root_depth = (getattr(graph.root_node, "soot_block") or {}).get('depth') or _set_depth(graph.root_node, RECURSION_LIMIT)
+    for node in graph.nodes:
+        if node.soot_block is None:
+            node.soot_block = {'depth': -1, 'idx': None}
+    return root_depth
 
 
 def valid_sub_root_node(sub_root_node, already_checked_nodes):


### PR DESCRIPTION
This PR add:
- A minor improvement to set_depth to avoid an error in signature computation. Set_depth halts after a certain amount of iterations, therefore some nodes might not be reached, leading to an error when the signature function tries to access it.

The error:
```
21:10:40 [WARNING] Bad expression: binary['cfg']['acyclic_graph']['signature'](128, True)[0]
21:10:40 [ERROR] 'NoneType' object is not subscriptable
Traceback (most recent call last):
  File "/home/user/.local/lib/python3.11/site-packages/pbox/helpers/items.py", line 89, in _exec
    r = eval2(expr, d, {}, whitelist_nodes=WL_NODES + _WL_EXTRA_NODES)
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/user/.local/lib/python3.11/site-packages/tinyscript/helpers/expressions.py", line 
122, in eval2
    return __eval(expression, globals, locals, blacklist_builtins, whitelist_nodes)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/user/.local/lib/python3.11/site-packages/tinyscript/helpers/expressions.py", line 58,
in __eval
    return eval(expr, globals, locals)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "<string>", line 1, in <module>
  File "/home/user/.local/lib/python3.11/site-packages/pbox/core/executable/cfg/graph.py", line 
146, in signature
    for successor in sorted(self.successors(node), key=lambda n: -n.soot_block['depth']):
                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/user/.local/lib/python3.11/site-packages/pbox/core/executable/cfg/graph.py", line 
146, in <lambda>
    for successor in sorted(self.successors(node), key=lambda n: -n.soot_block['depth']):
                                                                  ~~~~~~~~~~~~^^^^^^^^^
TypeError: 'NoneType' object is not subscriptable
```