### PR TITLE
Add split option to database select

### DIFF
--- a/src/files/tools/dataset
+++ b/src/files/tools/dataset
@@ -175,6 +175,7 @@ if __name__ == '__main__':
                         note="this removes all backups")
     select = cmds.add_parser("select", category="create/modify/delete", help="select a subset of the dataset")
     add_argument(select, "dsname", "dsname2", "number", "query")
+    select.add_argument("-s", "--split", action="store_true", help="split original dataset by removing the selected samples from the original")
     show = add_argument(cmds.add_parser("show", category="read", help="get an overview of the dataset"), "dsname")
     show.add_argument("-l", "--limit", default=10, type=int, help="number of executables to be displayed per format")
     show.add_argument("--per-format", action="store_true", help="display statistics per format")

--- a/src/lib/src/pbox/core/dataset/__init__.py
+++ b/src/lib/src/pbox/core/dataset/__init__.py
@@ -725,7 +725,7 @@ class Dataset(Entity):
         if init:  # if reverting to initial state, continue reverting
             self.revert(init=True)
     
-    def select(self, name2=None, query=None, limit=0, **kw):
+    def select(self, name2=None, query=None, limit=0, split=None, **kw):
         """ Select a subset from the current dataset based on multiple criteria. """
         self.logger.debug(f"selecting a subset of {self.basename} based on query '{query}'...")
         ds2 = self.__class__(name2)
@@ -736,6 +736,9 @@ class Dataset(Entity):
                     ds2._metadata['sources'].append(s)
                     break
             ds2[Executable(dataset=self, dataset2=ds2, hash=e.hash)] = self[e.hash, True]
+            if split:
+                del self[e.hash]
+        self._save()
         if hasattr(self, "_features") and len(self._features) > 0:
             ds2._features = {k: v for k, v in self._features.items()}
         ds2._save()


### PR DESCRIPTION
This PR adds:
- An extra option in the `dataset select` tool to remove the selected executables from the dataset they were selected from, effectively splitting the dataset into two parts: one passing the criteria provided to the select command and the other not passing those criteria