### PR TITLE
Add --true-class to model test

### DIFF
--- a/src/files/tools/model
+++ b/src/files/tools/model
@@ -59,6 +59,7 @@ if __name__ == '__main__':
     add_argument(test, "mdname", "executable", "features-set", "ignore-labels")
     test.add_argument("--sep", default=",", choices=",;|\t", help="set the CSV separator",
                       note="required when using input CSV data instead of a Dataset (no effect otherwise)")
+    test.add_argument("-T", "--true-class", help="class to be considered as True")
     train = sparsers.add_parser("train", category="create/modify/delete", help="train a model on the given dataset")
     train.add_argument("dataset", type=Dataset.load, help="dataset for training the model")
     train.add_argument("-a", "--algorithms-set", metavar="YAML", type=ts.file_exists, default=config['algorithms'],


### PR DESCRIPTION
This PR adds:
- The -T (--true-class) option for the `model test` command. Otherwise, the performance metrics of the model test command are incorrect and you get the following warning:
```
/home/user/.local/lib/python3.11/site-packages/sklearn/metrics/_classification.py:1509: UndefinedMetricWarning: Recall is ill-defined and being set to 0.0 in labels with no true samples. Use `zero_division` parameter to control this behavior.
  _warn_prf(average, modifier, f"{metric.capitalize()} is", len(result))
```