### PR TITLE
Integrate EP feature

### DIFF
--- a/src/lib/src/pbox/core/executable/cfg/__common__.py
+++ b/src/lib/src/pbox/core/executable/cfg/__common__.py
@@ -144,6 +144,10 @@ class CFG(GetItemMixin, ResetCachedPropertiesMixin):
     @property
     def edges(self):
         return self.graph.edges
+
+    @property
+    def entry(self):
+        return self.model.project.entry
     
     @property
     def graph(self):


### PR DESCRIPTION
This PR adds:
- A cfg property returning the address of the EP

I first tried:
```
binary['cfg']['model']['project']['entry']
ERROR: 'CFGModel' object is not subscriptable
```

Then tried:
```
binary['cfg']['_CFG__project']['entry']
KeyNotAllowedError: '_CFG__project'
```

Now:
```
binary['cfg']['entry']
```

Open to alternatives/suggestions