### PR TITLE
Fix auc=0 in model test

### DIFF
--- a/src/lib/src/pbox/core/model/__init__.py
+++ b/src/lib/src/pbox/core/model/__init__.py
@@ -235,7 +235,7 @@ class BaseModel(Entity):
         try:
             proba, dt2 = benchmark(self.pipeline.predict_proba)(self._data)
             dt += dt2
-            proba = proba[:, 0]
+            proba = proba[:, 1]
         except AttributeError:
             proba = None
         metrics = cls.metrics if isinstance(cls.metrics, (list, tuple)) else [cls.metrics]


### PR DESCRIPTION
This PR adds:
- A minor extension to commit d426481974dcabfe9295e5b2e71bfac97e856102 with the same fix for the `model test` command