### PR TITLE
Enhance `dataset plot features` with `--true-class` option

### DIFF
--- a/src/files/tools/dataset
+++ b/src/files/tools/dataset
@@ -136,7 +136,9 @@ if __name__ == '__main__':
                            note="by 'characteristic', it is meant either executable metadata or feature")
     add_argument(plot_char, "reduction-algorithm", "binary", "ncomponents", "perplexity")
     plot_feat = pcmds.add_parser("features", help="distribution of one or multiple features (bar chart)")
-    add_argument(plot_feat, "dsname", "feature", "multiclass")
+    add_argument(plot_feat, "dsname", "feature")
+    plot_feat_ = plot_feat.add_mutually_exclusive_group()
+    add_argument(plot_feat_, "multiclass", "true-class")
     figure_options(plot_feat)
     plot_featcomp = pcmds.add_parser("features-compare", help="compare feature difference with other datasets")
     add_argument(plot_featcomp, "dsname", "feature", "aggregate", "datasets", "max-features",

--- a/src/files/tools/model
+++ b/src/files/tools/model
@@ -59,7 +59,7 @@ if __name__ == '__main__':
     add_argument(test, "mdname", "executable", "features-set", "ignore-labels")
     test.add_argument("--sep", default=",", choices=",;|\t", help="set the CSV separator",
                       note="required when using input CSV data instead of a Dataset (no effect otherwise)")
-    test.add_argument("-T", "--true-class", metavar="CLASS", help="class to be considered as True")
+    add_argument(test, "true-class")
     train = sparsers.add_parser("train", category="create/modify/delete", help="train a model on the given dataset")
     train.add_argument("dataset", type=Dataset.load, help="dataset for training the model")
     train.add_argument("-a", "--algorithms-set", metavar="YAML", type=ts.file_exists, default=config['algorithms'],
@@ -71,8 +71,8 @@ if __name__ == '__main__':
     add_argument(train, "features-set")
     tgroup = train.add_mutually_exclusive_group()
     tgroup.add_argument("-m", "--multiclass", action="store_true", help="train the model using multiple label classes")
+    add_argument(tgroup, "true-class")
     train.add_argument("-r", "--reset", action="store_true", help="reset the model before (re)training")
-    tgroup.add_argument("-T", "--true-class", metavar="CLASS", help="class to be considered as True")
     train.add_argument("--cv", default=5, type=ts.pos_int, help="number of Cross-Validation folds")
     train.add_argument("--feature", action="extend", nargs="*", help="list of features to be selected")
     add_argument(train, "ignore-labels")

--- a/src/lib/src/pbox/core/dataset/visualization.py
+++ b/src/lib/src/pbox/core/dataset/visualization.py
@@ -58,7 +58,7 @@ def _characteristic_scatter_plot(dataset, characteristic=None, multiclass=True, 
 
 
 @save_figure
-def _features_bar_chart(dataset, feature=None, multiclass=False, scaler=None, **kw):
+def _features_bar_chart(dataset, feature=None, multiclass=False, scaler=None, true_class=None, **kw):
     """ Plot the distribution of the given feature or multiple features combined. """
     l = dataset.logger
     if feature is None:
@@ -71,6 +71,7 @@ def _features_bar_chart(dataset, feature=None, multiclass=False, scaler=None, **
     # data preparation
     feature = filter_features(dataset, feature)
     l.info(f"Counting values for feature{['', 's'][len(feature) > 1]} {', '.join(feature)}...")
+    true_class_cap = true_class[0].upper() + true_class[1:]
     #FIXME: for continuous values, convert to ranges to limit chart's height
     # start counting, keeping 'Not packed' counts separate (to prevent it from being sorted with others)
     counts_np, counts, labels, data = {}, {}, [], pd.DataFrame()
@@ -79,9 +80,11 @@ def _features_bar_chart(dataset, feature=None, multiclass=False, scaler=None, **
         data = pd.concat([data, pd.DataFrame.from_records([row])], ignore_index=True)
         v = tuple(row.values())
         counts_np.setdefault(v, 0)
-        counts.setdefault(v, {} if multiclass else {'Packed': 0})
+        counts.setdefault(v, {true_class_cap: 0} if true_class else {} if multiclass else {'Packed': 0})
         lbl = str(exe.label)
-        if lbl == NOT_PACKED:
+        if true_class and lbl == true_class:
+            counts[v][true_class_cap] += 1
+        elif lbl == NOT_PACKED or true_class:
             counts_np[v] += 1
         elif multiclass:
             lbl = packer.Packer.get(lbl).cname
@@ -107,6 +110,8 @@ def _features_bar_chart(dataset, feature=None, multiclass=False, scaler=None, **
         if multiclass:
             for lbl in labels:
                 d.setdefault(lbl, 0)
+        elif true_class:
+            d.setdefault(true_class_cap, 0)
         else:
             d.setdefault('Packed', 0)
     l.debug("sorting feature values...")
@@ -114,7 +119,7 @@ def _features_bar_chart(dataset, feature=None, multiclass=False, scaler=None, **
     counts = {k: {sk: sv for sk, sv in sorted(v.items(), key=lambda x: x[0].lower())} \
               for k, v in sorted(counts.items(), key=lambda x: x[0])}
     # merge counts of not packed and other counts
-    all_counts = {k: {'Not packed': v} for k, v in sorted(counts_np.items(), key=lambda x: x[0])}
+    all_counts = {k: {'Not ' + true_class if true_class else 'Not packed': v} for k, v in sorted(counts_np.items(), key=lambda x: x[0])}
     for k, v in counts.items():
         for sk, sv in v.items():
             all_counts[k][sk] = sv  # force keys order

--- a/src/lib/src/pbox/helpers/args.py
+++ b/src/lib/src/pbox/helpers/args.py
@@ -111,6 +111,8 @@ def add_argument(parser, *names, **kwargs):
         elif name == "reduction-algorithm":
             parser.add_argument("-a", "--reduction-algorithm", default="PCA", choices=("ICA", "PCA"),
                                 help="dimensionality reduction algorithm")
+        elif name == "true-class":
+            parser.add_argument("-T", "--true-class", metavar="CLASS", help="class to be considered as True")
         elif name == "xpname":
             parser.add_argument("name", type=experiment_exists(kwargs.get('force', False)),
                                 help=kwargs.get('help', "name of the experiment"), **params)


### PR DESCRIPTION
This PR adds:
- The `--true-class` option for `dataset plot features`

Example plot generated with `dataset plot features com-2a byte_0_after_ep -T compressor`

![byte_0_after_ep](https://github.com/packing-box/docker-packing-box/assets/90518865/da80d945-cc39-4a04-a949-62b6675fe723)

What it used to look like with `dataset plot features com-2a byte_0_after_ep`

![byte_0_after_ep](https://github.com/packing-box/docker-packing-box/assets/90518865/797c71ae-26a9-413f-9b68-ac68e97a5341)


