### PR TITLE
Enhance `dataset plot features` with `--num-values` option

### DIFF
--- a/src/files/tools/dataset
+++ b/src/files/tools/dataset
@@ -137,6 +137,9 @@ if __name__ == '__main__':
     add_argument(plot_char, "reduction-algorithm", "binary", "ncomponents", "perplexity")
     plot_feat = pcmds.add_parser("features", help="distribution of one or multiple features (bar chart)")
     add_argument(plot_feat, "dsname", "feature", "multiclass")
+    plot_feat.add_argument("-n", "--num-values", type=ts.pos_int, default=0,
+                        help="limit number of most occurring distict feature values in plot",
+                        note="0 means all")
     figure_options(plot_feat)
     plot_featcomp = pcmds.add_parser("features-compare", help="compare feature difference with other datasets")
     add_argument(plot_featcomp, "dsname", "feature", "aggregate", "datasets", "max-features",

--- a/src/lib/src/pbox/core/dataset/visualization.py
+++ b/src/lib/src/pbox/core/dataset/visualization.py
@@ -58,7 +58,7 @@ def _characteristic_scatter_plot(dataset, characteristic=None, multiclass=True, 
 
 
 @save_figure
-def _features_bar_chart(dataset, feature=None, multiclass=False, scaler=None, **kw):
+def _features_bar_chart(dataset, feature=None, num_values=None, multiclass=False, scaler=None, **kw):
     """ Plot the distribution of the given feature or multiple features combined. """
     l = dataset.logger
     if feature is None:
@@ -109,16 +109,19 @@ def _features_bar_chart(dataset, feature=None, multiclass=False, scaler=None, **
                 d.setdefault(lbl, 0)
         else:
             d.setdefault('Packed', 0)
-    l.debug("sorting feature values...")
-    # sort counts by feature value and by label
-    counts = {k: {sk: sv for sk, sv in sorted(v.items(), key=lambda x: x[0].lower())} \
-              for k, v in sorted(counts.items(), key=lambda x: x[0])}
     # merge counts of not packed and other counts
     all_counts = {k: {'Not packed': v} for k, v in sorted(counts_np.items(), key=lambda x: x[0])}
     for k, v in counts.items():
         for sk, sv in v.items():
             all_counts[k][sk] = sv  # force keys order
     counts = all_counts
+    if num_values:
+        l.debug(f"selecting {num_values} most occurring feature values...")
+        counts = dict(sorted(counts.items(), key=lambda x: sum(x[1].values()), reverse=True)[:num_values])
+    l.debug("sorting feature values...")
+    # sort counts by feature value and by label
+    counts = {k: {sk: sv for sk, sv in sorted(v.items(), key=lambda x: x[0].lower())} \
+              for k, v in sorted(counts.items(), key=lambda x: x[0])}
     l.debug("reformatting feature values...")
     vtype = str
     #  transform {0,1} to False|True
@@ -154,7 +157,8 @@ def _features_bar_chart(dataset, feature=None, multiclass=False, scaler=None, **
     labels = list(counts[next(iter(counts))].keys())
     # display plot
     plur = ["", "s"][len(feature) > 1]
-    x_label, y_label = f"Samples [%] for the selected feature{plur}", f"Feature{plur} values"
+    x_label, y_label = f"Samples [%] for the selected feature{plur}", \
+                       f"Feature{plur} values" + (f" (top {num_values})" if num_values else "")
     yticks = [str(k[0]) if isinstance(k, (tuple, list)) and len(k) == 1 else str(k) \
               for k in counts.keys()]
     plt.rcParams['font.family'] = ["serif"]


### PR DESCRIPTION
This PR adds:
- The `--num-values` option for `dataset plot features` to limit the amount of distinct feature values displayed on the plot (showing only the `--num-values` most occurring feature values)

Example plot generated with `dataset plot features com-2a byte_0_after_ep byte_1_after_ep byte_2_after_ep byte_3_after_ep byte_4_after_ep byte_5_after_ep -n 15`

![SMALL](https://github.com/packing-box/docker-packing-box/assets/90518865/151d87c9-34e6-485a-99a9-a35e53a5934e)

What it used to look like with `dataset plot features com-2a byte_0_after_ep byte_1_after_ep byte_2_after_ep byte_3_after_ep byte_4_after_ep byte_5_after_ep`

![HUGE](https://github.com/packing-box/docker-packing-box/assets/90518865/c7cd4d83-ebd5-4bb6-b797-2aae48069fed)



