### PR TITLE
Replace custom title wrap in `dataset plot features`

### DIFF
--- a/src/lib/src/pbox/core/dataset/visualization.py
+++ b/src/lib/src/pbox/core/dataset/visualization.py
@@ -7,7 +7,6 @@ from ...helpers import *
 
 lazy_load_module("packer", "pbox.core.items")
 lazy_load_module("seaborn")
-lazy_load_module("textwrap")
 
 
 @save_figure
@@ -136,7 +135,7 @@ def _features_bar_chart(dataset, feature=None, multiclass=False, scaler=None, **
     l.debug("plotting...")
     try:
         title = dataset._features[feature[0]] if len(feature) == 1 else \
-                "\n".join(textwrap.wrap(f"combination of {', '.join(dataset._features[f] for f in feature)}", 60))
+                "".join(f"combination of {', '.join(dataset._features[f] for f in feature)}")
         title = title[0].upper() + title[1:] + f" for dataset {dataset.name}"
     except KeyError as e:
         l.error(f"Feature '{e.args[0]}' does not exist in the target dataset.")
@@ -159,7 +158,7 @@ def _features_bar_chart(dataset, feature=None, multiclass=False, scaler=None, **
               for k in counts.keys()]
     plt.rcParams['font.family'] = ["serif"]
     plt.figure(figsize=(6, (len(title.splitlines()) * 24 + 11 * len(counts) + 120) / 80))
-    plt.title(title, pad=20, fontweight="bold", fontsize=16)
+    plt.title(title, pad=20, fontweight="bold", fontsize=16, wrap=True)
     plt.xlabel(x_label, fontdict={'size': 14})
     plt.ylabel(y_label, fontdict={'size': 14})
     starts = [0 for i in range(len(values[0]))]


### PR DESCRIPTION
This PR adds:
- Automatic title wrapping on plots generated by `dataset plot features` for a cleaner plot layout when feature descriptions are long

The custom title wrap for combined features is removed, as wrapping is now automatically handled for all titles.

Example plot generated with `dataset plot features cry-2 ep_ratio -T cryptor -n 20` (using #129 and #130)

What it used to look like:

![NO_WRAP](https://github.com/packing-box/docker-packing-box/assets/90518865/89f5d52c-8ea6-468b-b4fe-dbef362df9d1)

What it looks like now:

![WRAP](https://github.com/packing-box/docker-packing-box/assets/90518865/99ed3f98-f886-43b8-a1d4-8486193eb3ad)
