### PR TITLE
Add r8-r15 to general purpose registers

### DIFF
--- a/src/lib/src/pbox/constants.py
+++ b/src/lib/src/pbox/constants.py
@@ -183,7 +183,8 @@ bi.X86_64_JUMP_MNEMONICS = {"call", "jmp", "bnd jmp", "je", "jne", "jz", "jnz", 
 bi.X86_64_REGISTERS = {
     "Return value":              {"rax", "eax", "ax", "ah", "al"},
     "General-Purpose Registers": {"rbx", "rcx", "rdx", "ebx", "ecx", "edx", "bx", "bh", "bl", "cx", "ch", "cl", "dx",
-                                  "dh", "dl"},
+                                  "dh", "dl"} |
+                                 {f"r{i}{s}" for i in range(8, 16) for s in ("", "d", "w", "b")},
     "Segment Registers":         {"cs", "ds", "es", "fs", "gs", "ss"},
     "Function arguments":        {"rsi", "rdi", "esi", "edi"},
     "Stack Registers":           {"rbp", "rsp", "ebp", "esp"},


### PR DESCRIPTION
This PR adds:
- r8-r15 registers to the general purpose registers constant

Their 32-bit, 16-bit & 8-bit counterparts are also included, since even in 64-bit executables, the 8-bit version of a register can still be used to perform operations on this smaller part of a register.